### PR TITLE
Refactor activity registration APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@
 # Logs and databases #
 ######################
 *.log
+*.db
 *.sql
 *.sqlite
 

--- a/src/README.md
+++ b/src/README.md
@@ -2,7 +2,7 @@
 
 A super simple FastAPI application that allows students to view and sign up for extracurricular activities.
 
-The app now persists its core data in a local SQLite database with explicit models for activities, students, and registrations.
+The app persists its core data in a local SQLite database with explicit models for activities, students, and registrations.
 
 ## Features
 
@@ -31,10 +31,35 @@ The app now persists its core data in a local SQLite database with explicit mode
 
 ## API Endpoints
 
-| Method | Endpoint                                                          | Description                                                         |
-| ------ | ----------------------------------------------------------------- | ------------------------------------------------------------------- |
-| GET    | `/activities`                                                     | Get all activities with their details and current participant count |
-| POST   | `/activities/{activity_name}/signup?email=student@mergington.edu` | Sign up for an activity                                             |
+The app currently exposes both a legacy compatibility API and a normalized API.
+
+### Legacy compatibility endpoints
+
+| Method | Endpoint | Description |
+| ------ | -------- | ----------- |
+| GET | `/activities` | Get all activities with their details and current participant count |
+| POST | `/activities/{activity_name}/signup?email=student@mergington.edu` | Sign up for an activity |
+| DELETE | `/activities/{activity_name}/unregister?email=student@mergington.edu` | Unregister a student from an activity |
+
+### Normalized registration endpoints
+
+| Method | Endpoint | Description |
+| ------ | -------- | ----------- |
+| GET | `/api/activities` | List activities with stable IDs and availability counts |
+| GET | `/api/activities/{activity_id}` | Get one activity by ID |
+| GET | `/api/activities/{activity_id}/registrations` | List registrations for an activity |
+| POST | `/api/activities/{activity_id}/registrations` | Create a registration using a JSON request body |
+| DELETE | `/api/activities/{activity_id}/registrations/{registration_id}` | Cancel a registration by ID |
+| GET | `/api/students/{student_id}/registrations` | List registrations for one student |
+
+Example registration request body:
+
+```json
+{
+   "email": "student@mergington.edu",
+   "full_name": "Student Name"
+}
+```
 
 ## Data Model
 
@@ -61,4 +86,4 @@ The application now uses persistent core domain models:
 
 ## Persistence Notes
 
-The legacy endpoints remain the same for now, but the data is no longer stored in memory. Default activities are seeded into the database only on first startup.
+Default activities are seeded into the database only on first startup. The legacy endpoints remain available for the current frontend, while the normalized API is the target surface for future frontend updates.

--- a/src/README.md
+++ b/src/README.md
@@ -2,6 +2,8 @@
 
 A super simple FastAPI application that allows students to view and sign up for extracurricular activities.
 
+The app now persists its core data in a local SQLite database with explicit models for activities, students, and registrations.
+
 ## Features
 
 - View all available extracurricular activities
@@ -11,19 +13,21 @@ A super simple FastAPI application that allows students to view and sign up for 
 
 1. Install the dependencies:
 
-   ```
+   ```bash
    pip install fastapi uvicorn
    ```
 
 2. Run the application:
 
-   ```
+   ```bash
    python app.py
    ```
 
+   This will automatically create a local SQLite database file named `activities.db` in `src/` if it does not already exist.
+
 3. Open your browser and go to:
-   - API documentation: http://localhost:8000/docs
-   - Alternative documentation: http://localhost:8000/redoc
+   - API documentation: <http://localhost:8000/docs>
+   - Alternative documentation: <http://localhost:8000/redoc>
 
 ## API Endpoints
 
@@ -34,17 +38,27 @@ A super simple FastAPI application that allows students to view and sign up for 
 
 ## Data Model
 
-The application uses a simple data model with meaningful identifiers:
+The application now uses persistent core domain models:
 
-1. **Activities** - Uses activity name as identifier:
+1. **Activities**
 
    - Description
-   - Schedule
+   - Schedule text
+   - Category
    - Maximum number of participants allowed
-   - List of student emails who are signed up
+   - Active status
 
-2. **Students** - Uses email as identifier:
+2. **Students**
+
+   - Email
    - Name
-   - Grade level
+   - Optional grade or year
 
-All data is stored in memory, which means data will be reset when the server restarts.
+3. **Registrations**
+
+   - Link one student to one activity
+   - Track status for the signup lifecycle
+
+## Persistence Notes
+
+The legacy endpoints remain the same for now, but the data is no longer stored in memory. Default activities are seeded into the database only on first startup.

--- a/src/README.md
+++ b/src/README.md
@@ -8,6 +8,7 @@ The app persists its core data in a local SQLite database with explicit models f
 
 - View all available extracurricular activities
 - Sign up for activities
+- Unregister students using stable registration records in the normalized API
 
 ## Getting Started
 
@@ -86,4 +87,4 @@ The application now uses persistent core domain models:
 
 ## Persistence Notes
 
-Default activities are seeded into the database only on first startup. The legacy endpoints remain available for the current frontend, while the normalized API is the target surface for future frontend updates.
+Default activities are seeded into the database only on first startup. The legacy endpoints remain available for backward compatibility, while the static frontend now uses the normalized API endpoints for listing activities, creating registrations, and cancelling registrations.

--- a/src/app.py
+++ b/src/app.py
@@ -1,15 +1,12 @@
-"""
-High School Management System API
-
-A super simple FastAPI application that allows students to view and sign up
-for extracurricular activities at Mergington High School.
-"""
+"""High School Management System API."""
 
 from fastapi import FastAPI, HTTPException
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
 import os
 from pathlib import Path
+
+from storage import initialize_database, list_activities_legacy, signup_student, unregister_student
 
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
@@ -19,63 +16,7 @@ current_dir = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
 
-# In-memory activity database
-activities = {
-    "Chess Club": {
-        "description": "Learn strategies and compete in chess tournaments",
-        "schedule": "Fridays, 3:30 PM - 5:00 PM",
-        "max_participants": 12,
-        "participants": ["michael@mergington.edu", "daniel@mergington.edu"]
-    },
-    "Programming Class": {
-        "description": "Learn programming fundamentals and build software projects",
-        "schedule": "Tuesdays and Thursdays, 3:30 PM - 4:30 PM",
-        "max_participants": 20,
-        "participants": ["emma@mergington.edu", "sophia@mergington.edu"]
-    },
-    "Gym Class": {
-        "description": "Physical education and sports activities",
-        "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
-        "max_participants": 30,
-        "participants": ["john@mergington.edu", "olivia@mergington.edu"]
-    },
-    "Soccer Team": {
-        "description": "Join the school soccer team and compete in matches",
-        "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",
-        "max_participants": 22,
-        "participants": ["liam@mergington.edu", "noah@mergington.edu"]
-    },
-    "Basketball Team": {
-        "description": "Practice and play basketball with the school team",
-        "schedule": "Wednesdays and Fridays, 3:30 PM - 5:00 PM",
-        "max_participants": 15,
-        "participants": ["ava@mergington.edu", "mia@mergington.edu"]
-    },
-    "Art Club": {
-        "description": "Explore your creativity through painting and drawing",
-        "schedule": "Thursdays, 3:30 PM - 5:00 PM",
-        "max_participants": 15,
-        "participants": ["amelia@mergington.edu", "harper@mergington.edu"]
-    },
-    "Drama Club": {
-        "description": "Act, direct, and produce plays and performances",
-        "schedule": "Mondays and Wednesdays, 4:00 PM - 5:30 PM",
-        "max_participants": 20,
-        "participants": ["ella@mergington.edu", "scarlett@mergington.edu"]
-    },
-    "Math Club": {
-        "description": "Solve challenging problems and participate in math competitions",
-        "schedule": "Tuesdays, 3:30 PM - 4:30 PM",
-        "max_participants": 10,
-        "participants": ["james@mergington.edu", "benjamin@mergington.edu"]
-    },
-    "Debate Team": {
-        "description": "Develop public speaking and argumentation skills",
-        "schedule": "Fridays, 4:00 PM - 5:30 PM",
-        "max_participants": 12,
-        "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
-    }
-}
+initialize_database()
 
 
 @app.get("/")
@@ -85,48 +26,36 @@ def root():
 
 @app.get("/activities")
 def get_activities():
-    return activities
+    return list_activities_legacy()
 
 
-@app.post("/activities/{activity_name}/signup")
+@app.post(
+    "/activities/{activity_name}/signup",
+    responses={400: {"description": "Invalid signup request"}, 404: {"description": "Activity not found"}},
+)
 def signup_for_activity(activity_name: str, email: str):
     """Sign up a student for an activity"""
-    # Validate activity exists
-    if activity_name not in activities:
-        raise HTTPException(status_code=404, detail="Activity not found")
+    try:
+        signup_student(activity_name, email)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except OverflowError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
-    # Get the specific activity
-    activity = activities[activity_name]
-
-    # Validate student is not already signed up
-    if email in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is already signed up"
-        )
-
-    # Add student
-    activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}
 
 
-@app.delete("/activities/{activity_name}/unregister")
+@app.delete(
+    "/activities/{activity_name}/unregister",
+    responses={400: {"description": "Invalid unregister request"}},
+)
 def unregister_from_activity(activity_name: str, email: str):
     """Unregister a student from an activity"""
-    # Validate activity exists
-    if activity_name not in activities:
-        raise HTTPException(status_code=404, detail="Activity not found")
+    try:
+        unregister_student(activity_name, email)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
-    # Get the specific activity
-    activity = activities[activity_name]
-
-    # Validate student is signed up
-    if email not in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is not signed up for this activity"
-        )
-
-    # Remove student
-    activity["participants"].remove(email)
     return {"message": f"Unregistered {email} from {activity_name}"}

--- a/src/app.py
+++ b/src/app.py
@@ -1,12 +1,26 @@
 """High School Management System API."""
 
+from typing import Optional
+
 from fastapi import FastAPI, HTTPException
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
 import os
 from pathlib import Path
+from pydantic import BaseModel
 
-from storage import initialize_database, list_activities_legacy, signup_student, unregister_student
+from storage import (
+    cancel_registration,
+    get_activity,
+    initialize_database,
+    list_activities,
+    list_activities_legacy,
+    list_activity_registrations,
+    list_student_registrations,
+    register_student_for_activity,
+    signup_student,
+    unregister_student,
+)
 
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
@@ -19,6 +33,17 @@ app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
 initialize_database()
 
 
+class RegistrationCreateRequest(BaseModel):
+    email: str
+    full_name: Optional[str] = None
+
+
+def _detail_from_exception(error: Exception) -> str:
+    if isinstance(error, KeyError) and error.args:
+        return str(error.args[0])
+    return str(error)
+
+
 @app.get("/")
 def root():
     return RedirectResponse(url="/static/index.html")
@@ -27,6 +52,90 @@ def root():
 @app.get("/activities")
 def get_activities():
     return list_activities_legacy()
+
+
+@app.get("/api/activities")
+def get_normalized_activities():
+    return {"activities": list_activities()}
+
+
+@app.get(
+    "/api/activities/{activity_id}",
+    responses={404: {"description": "Activity not found"}},
+)
+def get_activity_detail(activity_id: int):
+    try:
+        return get_activity(activity_id)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=_detail_from_exception(exc)) from exc
+
+
+@app.get(
+    "/api/activities/{activity_id}/registrations",
+    responses={404: {"description": "Activity not found"}},
+)
+def get_activity_registration_list(activity_id: int):
+    try:
+        return {
+            "activity": get_activity(activity_id),
+            "registrations": list_activity_registrations(activity_id),
+        }
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=_detail_from_exception(exc)) from exc
+
+
+@app.post(
+    "/api/activities/{activity_id}/registrations",
+    status_code=201,
+    responses={400: {"description": "Invalid registration request"}, 404: {"description": "Activity not found"}},
+)
+def create_registration(activity_id: int, payload: RegistrationCreateRequest):
+    try:
+        registration = register_student_for_activity(activity_id, payload.email, payload.full_name)
+        activity = get_activity(activity_id)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=_detail_from_exception(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=_detail_from_exception(exc)) from exc
+    except OverflowError as exc:
+        raise HTTPException(status_code=400, detail=_detail_from_exception(exc)) from exc
+
+    return {
+        "message": f"Registered {registration['student']['email']} for {activity['name']}",
+        "registration": registration,
+        "activity": activity,
+    }
+
+
+@app.delete(
+    "/api/activities/{activity_id}/registrations/{registration_id}",
+    responses={400: {"description": "Invalid cancellation request"}, 404: {"description": "Resource not found"}},
+)
+def delete_registration(activity_id: int, registration_id: int):
+    try:
+        registration = cancel_registration(activity_id, registration_id)
+        activity = get_activity(activity_id)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=_detail_from_exception(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=_detail_from_exception(exc)) from exc
+
+    return {
+        "message": f"Cancelled registration {registration_id} for {activity['name']}",
+        "registration": registration,
+        "activity": activity,
+    }
+
+
+@app.get(
+    "/api/students/{student_id}/registrations",
+    responses={404: {"description": "Student not found"}},
+)
+def get_student_registration_list(student_id: int):
+    try:
+        return {"registrations": list_student_registrations(student_id)}
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=_detail_from_exception(exc)) from exc
 
 
 @app.post(
@@ -38,24 +147,26 @@ def signup_for_activity(activity_name: str, email: str):
     try:
         signup_student(activity_name, email)
     except KeyError as exc:
-        raise HTTPException(status_code=404, detail=str(exc)) from exc
+        raise HTTPException(status_code=404, detail=_detail_from_exception(exc)) from exc
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        raise HTTPException(status_code=400, detail=_detail_from_exception(exc)) from exc
     except OverflowError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        raise HTTPException(status_code=400, detail=_detail_from_exception(exc)) from exc
 
     return {"message": f"Signed up {email} for {activity_name}"}
 
 
 @app.delete(
     "/activities/{activity_name}/unregister",
-    responses={400: {"description": "Invalid unregister request"}},
+    responses={400: {"description": "Invalid unregister request"}, 404: {"description": "Activity not found"}},
 )
 def unregister_from_activity(activity_name: str, email: str):
     """Unregister a student from an activity"""
     try:
         unregister_student(activity_name, email)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=_detail_from_exception(exc)) from exc
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        raise HTTPException(status_code=400, detail=_detail_from_exception(exc)) from exc
 
     return {"message": f"Unregistered {email} from {activity_name}"}

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -1,47 +1,98 @@
+async function fetchJson(url, options) {
+  const response = await fetch(url, options);
+  const payload = await response.json();
+
+  if (!response.ok) {
+    throw new Error(payload.detail || payload.message || "Request failed");
+  }
+
+  return payload;
+}
+
 document.addEventListener("DOMContentLoaded", () => {
   const activitiesList = document.getElementById("activities-list");
   const activitySelect = document.getElementById("activity");
   const signupForm = document.getElementById("signup-form");
+  const fullNameInput = document.getElementById("full-name");
   const messageDiv = document.getElementById("message");
+  const defaultSelectMarkup =
+    '<option value="">-- Select an activity --</option>';
+  let messageTimeoutId;
 
-  // Function to fetch activities from API
+  function showMessage(text, type) {
+    messageDiv.textContent = text;
+    messageDiv.className = type;
+    messageDiv.classList.remove("hidden");
+
+    globalThis.clearTimeout(messageTimeoutId);
+    messageTimeoutId = globalThis.setTimeout(() => {
+      messageDiv.classList.add("hidden");
+    }, 5000);
+  }
+
   async function fetchActivities() {
     try {
-      const response = await fetch("/activities");
-      const activities = await response.json();
+      const activitiesResponse = await fetchJson("/api/activities");
+      const activities = activitiesResponse.activities;
+      const registrationResponses = await Promise.all(
+        activities.map((activity) =>
+          fetchJson(`/api/activities/${activity.id}/registrations`)
+        )
+      );
 
-      // Clear loading message
       activitiesList.innerHTML = "";
+      activitySelect.innerHTML = defaultSelectMarkup;
 
-      // Populate activities list
-      Object.entries(activities).forEach(([name, details]) => {
+      activities.forEach((activity, index) => {
+        const registrations = registrationResponses[index].registrations.filter(
+          (registration) => registration.status === "registered"
+        );
         const activityCard = document.createElement("div");
         activityCard.className = "activity-card";
-
-        const spotsLeft =
-          details.max_participants - details.participants.length;
-
-        // Create participants HTML with delete icons instead of bullet points
         const participantsHTML =
-          details.participants.length > 0
+          registrations.length > 0
             ? `<div class="participants-section">
-              <h5>Participants:</h5>
+              <h5>Registered Students</h5>
               <ul class="participants-list">
-                ${details.participants
+                ${registrations
                   .map(
-                    (email) =>
-                      `<li><span class="participant-email">${email}</span><button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button></li>`
+                    (registration) =>
+                      `<li>
+                        <div class="participant-copy">
+                          <span class="participant-name">${registration.student.full_name}</span>
+                          <span class="participant-email">${registration.student.email}</span>
+                        </div>
+                        <button class="delete-btn" data-activity-id="${activity.id}" data-registration-id="${registration.id}">Remove</button>
+                      </li>`
                   )
                   .join("")}
               </ul>
             </div>`
-            : `<p><em>No participants yet</em></p>`;
+            : `<p><em>No registered students yet</em></p>`;
+
+        const availabilityText =
+          activity.available_spots > 0
+            ? `${activity.available_spots} spots left`
+            : "Full";
+        const waitlistMarkup =
+          activity.waitlisted_count > 0
+            ? `<p><strong>Waitlist:</strong> ${activity.waitlisted_count} students</p>`
+            : "";
+        const locationMarkup = activity.location
+          ? `<p><strong>Location:</strong> ${activity.location}</p>`
+          : "";
 
         activityCard.innerHTML = `
-          <h4>${name}</h4>
-          <p>${details.description}</p>
-          <p><strong>Schedule:</strong> ${details.schedule}</p>
-          <p><strong>Availability:</strong> ${spotsLeft} spots left</p>
+          <div class="activity-heading">
+            <h4>${activity.name}</h4>
+            <span class="activity-category">${activity.category}</span>
+          </div>
+          <p>${activity.description}</p>
+          <p><strong>Schedule:</strong> ${activity.schedule_text}</p>
+          ${locationMarkup}
+          <p><strong>Availability:</strong> ${availabilityText}</p>
+          <p><strong>Registered:</strong> ${activity.registered_count} / ${activity.max_participants}</p>
+          ${waitlistMarkup}
           <div class="participants-container">
             ${participantsHTML}
           </div>
@@ -49,112 +100,71 @@ document.addEventListener("DOMContentLoaded", () => {
 
         activitiesList.appendChild(activityCard);
 
-        // Add option to select dropdown
         const option = document.createElement("option");
-        option.value = name;
-        option.textContent = name;
+        option.value = String(activity.id);
+        option.textContent = `${activity.name} (${availabilityText})`;
         activitySelect.appendChild(option);
       });
 
-      // Add event listeners to delete buttons
       document.querySelectorAll(".delete-btn").forEach((button) => {
         button.addEventListener("click", handleUnregister);
       });
     } catch (error) {
       activitiesList.innerHTML =
         "<p>Failed to load activities. Please try again later.</p>";
+      activitySelect.innerHTML = defaultSelectMarkup;
       console.error("Error fetching activities:", error);
     }
   }
 
-  // Handle unregister functionality
   async function handleUnregister(event) {
     const button = event.target;
-    const activity = button.getAttribute("data-activity");
-    const email = button.getAttribute("data-email");
+    const { activityId, registrationId } = button.dataset;
 
     try {
-      const response = await fetch(
-        `/activities/${encodeURIComponent(
-          activity
-        )}/unregister?email=${encodeURIComponent(email)}`,
-        {
-          method: "DELETE",
-        }
+      const result = await fetchJson(
+        `/api/activities/${encodeURIComponent(
+          activityId
+        )}/registrations/${encodeURIComponent(registrationId)}`,
+        { method: "DELETE" }
       );
-
-      const result = await response.json();
-
-      if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
-
-        // Refresh activities list to show updated participants
-        fetchActivities();
-      } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
-      }
-
-      messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
+      showMessage(result.message, "success");
+      fetchActivities();
     } catch (error) {
-      messageDiv.textContent = "Failed to unregister. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
+      showMessage(error.message || "Failed to unregister. Please try again.", "error");
       console.error("Error unregistering:", error);
     }
   }
 
-  // Handle form submission
   signupForm.addEventListener("submit", async (event) => {
     event.preventDefault();
 
     const email = document.getElementById("email").value;
-    const activity = document.getElementById("activity").value;
+    const fullName = fullNameInput.value.trim();
+    const activityId = document.getElementById("activity").value;
 
     try {
-      const response = await fetch(
-        `/activities/${encodeURIComponent(
-          activity
-        )}/signup?email=${encodeURIComponent(email)}`,
+      const result = await fetchJson(
+        `/api/activities/${encodeURIComponent(activityId)}/registrations`,
         {
           method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            email,
+            full_name: fullName || null,
+          }),
         }
       );
-
-      const result = await response.json();
-
-      if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
-        signupForm.reset();
-
-        // Refresh activities list to show updated participants
-        fetchActivities();
-      } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
-      }
-
-      messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
+      showMessage(result.message, "success");
+      signupForm.reset();
+      fetchActivities();
     } catch (error) {
-      messageDiv.textContent = "Failed to sign up. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
+      showMessage(error.message || "Failed to sign up. Please try again.", "error");
       console.error("Error signing up:", error);
     }
   });
 
-  // Initialize app
   fetchActivities();
 });

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -25,6 +25,10 @@
         <h3>Sign Up for an Activity</h3>
         <form id="signup-form">
           <div class="form-group">
+            <label for="full-name">Student Name:</label>
+            <input type="text" id="full-name" placeholder="Taylor Student" />
+          </div>
+          <div class="form-group">
             <label for="email">Student Email:</label>
             <input type="email" id="email" required placeholder="your-email@mergington.edu" />
           </div>

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -66,8 +66,27 @@ section h3 {
 }
 
 .activity-card h4 {
-  margin-bottom: 10px;
+  margin-bottom: 0;
   color: #0066cc;
+}
+
+.activity-heading {
+  align-items: center;
+  display: flex;
+  gap: 10px;
+  justify-content: space-between;
+  margin-bottom: 10px;
+}
+
+.activity-category {
+  background-color: #e8eaf6;
+  border-radius: 999px;
+  color: #1a237e;
+  font-size: 12px;
+  font-weight: bold;
+  letter-spacing: 0.04em;
+  padding: 4px 10px;
+  text-transform: uppercase;
 }
 
 .activity-card p {
@@ -96,8 +115,9 @@ section h3 {
   padding: 4px 0;
   position: relative;
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
+  gap: 12px;
 }
 
 /* Remove the bullet point pseudo-element */
@@ -105,24 +125,37 @@ section h3 {
   display: none;
 }
 
+.participant-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.participant-name {
+  color: #1f2937;
+  font-weight: bold;
+}
+
 .participant-email {
+  color: #666;
   flex-grow: 1;
   margin-right: 8px;
 }
 
 .delete-btn {
-  background: none;
-  border: none;
+  background-color: #ffebee;
+  border: 1px solid #ef9a9a;
   color: #c62828;
   cursor: pointer;
-  font-size: 14px;
-  padding: 2px 5px;
+  font-size: 13px;
+  padding: 6px 10px;
   transition: all 0.2s;
-  border-radius: 3px;
+  border-radius: 999px;
+  white-space: nowrap;
 }
 
 .delete-btn:hover {
-  background-color: #ffebee;
+  background-color: #ffcdd2;
 }
 
 .participants-section p {

--- a/src/storage.py
+++ b/src/storage.py
@@ -7,6 +7,10 @@ from pathlib import Path
 
 DB_PATH = Path(__file__).with_name("activities.db")
 
+ACTIVITY_NOT_FOUND = "Activity not found"
+STUDENT_NOT_FOUND = "Student not found"
+REGISTRATION_NOT_FOUND = "Registration not found"
+
 REGISTRATION_STATUS_REGISTERED = "registered"
 REGISTRATION_STATUS_WAITLISTED = "waitlisted"
 REGISTRATION_STATUS_CANCELLED = "cancelled"
@@ -216,7 +220,107 @@ def _full_name_from_email(email: str) -> str:
     return " ".join(part.capitalize() for part in local_part.replace(".", " ").replace("_", " ").split())
 
 
-def list_activities_legacy() -> dict[str, dict]:
+def _serialize_activity(row: sqlite3.Row) -> dict:
+    registered_count = row["registered_count"] or 0
+    waitlisted_count = row["waitlisted_count"] or 0
+    available_spots = row["max_participants"] - registered_count
+    if available_spots < 0:
+        available_spots = 0
+
+    return {
+        "id": row["id"],
+        "name": row["name"],
+        "description": row["description"],
+        "schedule_text": row["schedule_text"],
+        "location": row["location"],
+        "category": row["category"],
+        "max_participants": row["max_participants"],
+        "registered_count": registered_count,
+        "waitlisted_count": waitlisted_count,
+        "available_spots": available_spots,
+        "is_active": bool(row["is_active"]),
+        "created_at": row["created_at"],
+        "updated_at": row["updated_at"],
+    }
+
+
+def _serialize_registration(row: sqlite3.Row) -> dict:
+    return {
+        "id": row["registration_id"],
+        "activity_id": row["activity_id"],
+        "student": {
+            "id": row["student_id"],
+            "email": row["email"],
+            "full_name": row["full_name"],
+            "grade_or_year": row["grade_or_year"],
+            "phone_number": row["phone_number"],
+            "is_active": bool(row["student_is_active"]),
+        },
+        "status": row["status"],
+        "notes": row["notes"],
+        "registered_at": row["registered_at"],
+        "updated_at": row["updated_at"],
+    }
+
+
+def _get_activity_by_id_row(connection: sqlite3.Connection, activity_id: int) -> sqlite3.Row | None:
+    return connection.execute(
+        """
+        SELECT
+            a.id,
+            a.name,
+            a.description,
+            a.schedule_text,
+            a.location,
+            a.category,
+            a.max_participants,
+            a.is_active,
+            a.created_at,
+            a.updated_at,
+            COALESCE(SUM(CASE WHEN r.status = ? THEN 1 ELSE 0 END), 0) AS registered_count,
+            COALESCE(SUM(CASE WHEN r.status = ? THEN 1 ELSE 0 END), 0) AS waitlisted_count
+        FROM activities a
+        LEFT JOIN registrations r ON r.activity_id = a.id
+        WHERE a.id = ?
+        GROUP BY a.id
+        """,
+        (REGISTRATION_STATUS_REGISTERED, REGISTRATION_STATUS_WAITLISTED, activity_id),
+    ).fetchone()
+
+
+def _get_activity_id_by_name(connection: sqlite3.Connection, activity_name: str) -> int | None:
+    row = connection.execute(
+        "SELECT id FROM activities WHERE name = ? AND is_active = 1",
+        (activity_name,),
+    ).fetchone()
+    return row["id"] if row else None
+
+
+def _get_registration_row(connection: sqlite3.Connection, registration_id: int) -> sqlite3.Row | None:
+    return connection.execute(
+        """
+        SELECT
+            r.id AS registration_id,
+            r.activity_id,
+            r.status,
+            r.notes,
+            r.registered_at,
+            r.updated_at,
+            s.id AS student_id,
+            s.email,
+            s.full_name,
+            s.grade_or_year,
+            s.phone_number,
+            s.is_active AS student_is_active
+        FROM registrations r
+        JOIN students s ON s.id = r.student_id
+        WHERE r.id = ?
+        """,
+        (registration_id,),
+    ).fetchone()
+
+
+def list_activities() -> list[dict]:
     with get_connection() as connection:
         rows = connection.execute(
             """
@@ -225,58 +329,135 @@ def list_activities_legacy() -> dict[str, dict]:
                 a.name,
                 a.description,
                 a.schedule_text,
+                a.location,
+                a.category,
                 a.max_participants,
-                s.email
+                a.is_active,
+                a.created_at,
+                a.updated_at,
+                COALESCE(SUM(CASE WHEN r.status = ? THEN 1 ELSE 0 END), 0) AS registered_count,
+                COALESCE(SUM(CASE WHEN r.status = ? THEN 1 ELSE 0 END), 0) AS waitlisted_count
             FROM activities a
-            LEFT JOIN registrations r
-                ON r.activity_id = a.id AND r.status = ?
-            LEFT JOIN students s
-                ON s.id = r.student_id
+            LEFT JOIN registrations r ON r.activity_id = a.id
             WHERE a.is_active = 1
-            ORDER BY a.name, s.email
+            GROUP BY a.id
+            ORDER BY a.name
             """,
-            (REGISTRATION_STATUS_REGISTERED,),
+            (REGISTRATION_STATUS_REGISTERED, REGISTRATION_STATUS_WAITLISTED),
         ).fetchall()
 
+    return [_serialize_activity(row) for row in rows]
+
+
+def get_activity(activity_id: int) -> dict:
+    with get_connection() as connection:
+        row = _get_activity_by_id_row(connection, activity_id)
+        if not row or not row["is_active"]:
+            raise KeyError(ACTIVITY_NOT_FOUND)
+
+    return _serialize_activity(row)
+
+
+def list_activity_registrations(activity_id: int) -> list[dict]:
+    with get_connection() as connection:
+        activity_row = _get_activity_by_id_row(connection, activity_id)
+        if not activity_row or not activity_row["is_active"]:
+            raise KeyError(ACTIVITY_NOT_FOUND)
+
+        rows = connection.execute(
+            """
+            SELECT
+                r.id AS registration_id,
+                r.activity_id,
+                r.status,
+                r.notes,
+                r.registered_at,
+                r.updated_at,
+                s.id AS student_id,
+                s.email,
+                s.full_name,
+                s.grade_or_year,
+                s.phone_number,
+                s.is_active AS student_is_active
+            FROM registrations r
+            JOIN students s ON s.id = r.student_id
+            WHERE r.activity_id = ?
+            ORDER BY r.registered_at DESC, r.id DESC
+            """,
+            (activity_id,),
+        ).fetchall()
+
+    return [_serialize_registration(row) for row in rows]
+
+
+def list_student_registrations(student_id: int) -> list[dict]:
+    with get_connection() as connection:
+        rows = connection.execute(
+            """
+            SELECT
+                r.id AS registration_id,
+                r.activity_id,
+                r.status,
+                r.notes,
+                r.registered_at,
+                r.updated_at,
+                s.id AS student_id,
+                s.email,
+                s.full_name,
+                s.grade_or_year,
+                s.phone_number,
+                s.is_active AS student_is_active
+            FROM registrations r
+            JOIN students s ON s.id = r.student_id
+            WHERE s.id = ?
+            ORDER BY r.registered_at DESC, r.id DESC
+            """,
+            (student_id,),
+        ).fetchall()
+        if not rows:
+            student_exists = connection.execute(
+                "SELECT id FROM students WHERE id = ?",
+                (student_id,),
+            ).fetchone()
+            if not student_exists:
+                raise KeyError(STUDENT_NOT_FOUND)
+
+    return [_serialize_registration(row) for row in rows]
+
+
+def list_activities_legacy() -> dict[str, dict]:
     activities: dict[str, dict] = {}
-    for row in rows:
-        name = row["name"]
-        if name not in activities:
-            activities[name] = {
-                "description": row["description"],
-                "schedule": row["schedule_text"],
-                "max_participants": row["max_participants"],
-                "participants": [],
-            }
-        if row["email"]:
-            activities[name]["participants"].append(row["email"])
+    for activity in list_activities():
+        activities[activity["name"]] = {
+            "description": activity["description"],
+            "schedule": activity["schedule_text"],
+            "max_participants": activity["max_participants"],
+            "participants": [
+                registration["student"]["email"]
+                for registration in list_activity_registrations(activity["id"])
+                if registration["status"] == REGISTRATION_STATUS_REGISTERED
+            ],
+        }
 
     return activities
 
 
-def signup_student(activity_name: str, email: str) -> None:
+def register_student_for_activity(activity_id: int, email: str, full_name: str | None = None) -> dict:
     normalized_email = email.strip().lower()
     with get_connection() as connection:
-        activity = connection.execute(
-            "SELECT id, max_participants FROM activities WHERE name = ? AND is_active = 1",
-            (activity_name,),
-        ).fetchone()
-        if not activity:
-            raise KeyError("Activity not found")
+        activity = _get_activity_by_id_row(connection, activity_id)
+        if not activity or not activity["is_active"]:
+            raise KeyError(ACTIVITY_NOT_FOUND)
 
-        student_id = _ensure_student(connection, normalized_email)
+        student_id = _ensure_student(connection, normalized_email, full_name)
         existing_registration = connection.execute(
             "SELECT id, status FROM registrations WHERE activity_id = ? AND student_id = ?",
-            (activity["id"], student_id),
+            (activity_id, student_id),
         ).fetchone()
         if existing_registration and existing_registration["status"] != REGISTRATION_STATUS_CANCELLED:
-            raise ValueError("Student is already signed up")
+            raise ValueError("Student is already registered for this activity")
 
-        registered_count = connection.execute(
-            "SELECT COUNT(*) AS count FROM registrations WHERE activity_id = ? AND status = ?",
-            (activity["id"], REGISTRATION_STATUS_REGISTERED),
-        ).fetchone()["count"]
-        if registered_count >= activity["max_participants"]:
+        if activity["registered_count"] >= activity["max_participants"]:
             raise OverflowError("Activity is full")
 
         if existing_registration:
@@ -288,20 +469,60 @@ def signup_student(activity_name: str, email: str) -> None:
                 """,
                 (REGISTRATION_STATUS_REGISTERED, existing_registration["id"]),
             )
-            return
+            registration = _get_registration_row(connection, existing_registration["id"])
+            return _serialize_registration(registration)
 
-        connection.execute(
+        cursor = connection.execute(
             """
             INSERT INTO registrations (activity_id, student_id, status)
             VALUES (?, ?, ?)
             """,
-            (activity["id"], student_id, REGISTRATION_STATUS_REGISTERED),
+            (activity_id, student_id, REGISTRATION_STATUS_REGISTERED),
         )
+        registration = _get_registration_row(connection, cursor.lastrowid)
+
+    return _serialize_registration(registration)
+
+
+def cancel_registration(activity_id: int, registration_id: int) -> dict:
+    with get_connection() as connection:
+        activity = _get_activity_by_id_row(connection, activity_id)
+        if not activity or not activity["is_active"]:
+            raise KeyError(ACTIVITY_NOT_FOUND)
+
+        registration = connection.execute(
+            "SELECT id, status FROM registrations WHERE id = ? AND activity_id = ?",
+            (registration_id, activity_id),
+        ).fetchone()
+        if not registration:
+            raise KeyError(REGISTRATION_NOT_FOUND)
+        if registration["status"] == REGISTRATION_STATUS_CANCELLED:
+            raise ValueError("Registration is already cancelled")
+
+        connection.execute(
+            "UPDATE registrations SET status = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?",
+            (REGISTRATION_STATUS_CANCELLED, registration_id),
+        )
+        updated_registration = _get_registration_row(connection, registration_id)
+
+    return _serialize_registration(updated_registration)
+
+
+def signup_student(activity_name: str, email: str) -> None:
+    with get_connection() as connection:
+        activity_id = _get_activity_id_by_name(connection, activity_name)
+    if activity_id is None:
+        raise KeyError(ACTIVITY_NOT_FOUND)
+    register_student_for_activity(activity_id, email)
 
 
 def unregister_student(activity_name: str, email: str) -> None:
     normalized_email = email.strip().lower()
     with get_connection() as connection:
+        activity_id = _get_activity_id_by_name(connection, activity_name)
+        if activity_id is None:
+            raise KeyError(ACTIVITY_NOT_FOUND)
+
         registration = connection.execute(
             """
             SELECT r.id
@@ -317,7 +538,4 @@ def unregister_student(activity_name: str, email: str) -> None:
         if not registration:
             raise ValueError("Student is not signed up for this activity")
 
-        connection.execute(
-            "UPDATE registrations SET status = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?",
-            (REGISTRATION_STATUS_CANCELLED, registration["id"]),
-        )
+    cancel_registration(activity_id, registration["id"])

--- a/src/storage.py
+++ b/src/storage.py
@@ -1,0 +1,323 @@
+from __future__ import annotations
+
+import sqlite3
+from contextlib import contextmanager
+from pathlib import Path
+
+
+DB_PATH = Path(__file__).with_name("activities.db")
+
+REGISTRATION_STATUS_REGISTERED = "registered"
+REGISTRATION_STATUS_WAITLISTED = "waitlisted"
+REGISTRATION_STATUS_CANCELLED = "cancelled"
+
+
+DEFAULT_ACTIVITIES = [
+    {
+        "name": "Chess Club",
+        "description": "Learn strategies and compete in chess tournaments",
+        "schedule_text": "Fridays, 3:30 PM - 5:00 PM",
+        "category": "club",
+        "location": None,
+        "max_participants": 12,
+        "participants": ["michael@mergington.edu", "daniel@mergington.edu"],
+    },
+    {
+        "name": "Programming Class",
+        "description": "Learn programming fundamentals and build software projects",
+        "schedule_text": "Tuesdays and Thursdays, 3:30 PM - 4:30 PM",
+        "category": "class",
+        "location": None,
+        "max_participants": 20,
+        "participants": ["emma@mergington.edu", "sophia@mergington.edu"],
+    },
+    {
+        "name": "Gym Class",
+        "description": "Physical education and sports activities",
+        "schedule_text": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
+        "category": "class",
+        "location": None,
+        "max_participants": 30,
+        "participants": ["john@mergington.edu", "olivia@mergington.edu"],
+    },
+    {
+        "name": "Soccer Team",
+        "description": "Join the school soccer team and compete in matches",
+        "schedule_text": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",
+        "category": "team",
+        "location": None,
+        "max_participants": 22,
+        "participants": ["liam@mergington.edu", "noah@mergington.edu"],
+    },
+    {
+        "name": "Basketball Team",
+        "description": "Practice and play basketball with the school team",
+        "schedule_text": "Wednesdays and Fridays, 3:30 PM - 5:00 PM",
+        "category": "team",
+        "location": None,
+        "max_participants": 15,
+        "participants": ["ava@mergington.edu", "mia@mergington.edu"],
+    },
+    {
+        "name": "Art Club",
+        "description": "Explore your creativity through painting and drawing",
+        "schedule_text": "Thursdays, 3:30 PM - 5:00 PM",
+        "category": "club",
+        "location": None,
+        "max_participants": 15,
+        "participants": ["amelia@mergington.edu", "harper@mergington.edu"],
+    },
+    {
+        "name": "Drama Club",
+        "description": "Act, direct, and produce plays and performances",
+        "schedule_text": "Mondays and Wednesdays, 4:00 PM - 5:30 PM",
+        "category": "club",
+        "location": None,
+        "max_participants": 20,
+        "participants": ["ella@mergington.edu", "scarlett@mergington.edu"],
+    },
+    {
+        "name": "Math Club",
+        "description": "Solve challenging problems and participate in math competitions",
+        "schedule_text": "Tuesdays, 3:30 PM - 4:30 PM",
+        "category": "club",
+        "location": None,
+        "max_participants": 10,
+        "participants": ["james@mergington.edu", "benjamin@mergington.edu"],
+    },
+    {
+        "name": "Debate Team",
+        "description": "Develop public speaking and argumentation skills",
+        "schedule_text": "Fridays, 4:00 PM - 5:30 PM",
+        "category": "team",
+        "location": None,
+        "max_participants": 12,
+        "participants": ["charlotte@mergington.edu", "henry@mergington.edu"],
+    },
+]
+
+
+@contextmanager
+def get_connection():
+    connection = sqlite3.connect(DB_PATH)
+    connection.row_factory = sqlite3.Row
+    connection.execute("PRAGMA foreign_keys = ON")
+    try:
+        yield connection
+        connection.commit()
+    finally:
+        connection.close()
+
+
+def initialize_database() -> None:
+    with get_connection() as connection:
+        connection.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS students (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                email TEXT NOT NULL UNIQUE,
+                full_name TEXT NOT NULL,
+                grade_or_year TEXT,
+                phone_number TEXT,
+                is_active INTEGER NOT NULL DEFAULT 1,
+                created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+            );
+
+            CREATE TABLE IF NOT EXISTS activities (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL UNIQUE,
+                description TEXT NOT NULL,
+                schedule_text TEXT NOT NULL,
+                location TEXT,
+                category TEXT NOT NULL,
+                max_participants INTEGER NOT NULL,
+                is_active INTEGER NOT NULL DEFAULT 1,
+                created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+            );
+
+            CREATE TABLE IF NOT EXISTS registrations (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                activity_id INTEGER NOT NULL,
+                student_id INTEGER NOT NULL,
+                status TEXT NOT NULL DEFAULT 'registered' CHECK(status IN ('registered', 'waitlisted', 'cancelled')),
+                notes TEXT,
+                registered_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE(activity_id, student_id),
+                FOREIGN KEY(activity_id) REFERENCES activities(id) ON DELETE CASCADE,
+                FOREIGN KEY(student_id) REFERENCES students(id) ON DELETE CASCADE
+            );
+            """
+        )
+        _seed_default_data(connection)
+
+
+def _seed_default_data(connection: sqlite3.Connection) -> None:
+    existing_count = connection.execute("SELECT COUNT(*) AS count FROM activities").fetchone()["count"]
+    if existing_count:
+        return
+
+    for activity in DEFAULT_ACTIVITIES:
+        cursor = connection.execute(
+            """
+            INSERT INTO activities (name, description, schedule_text, location, category, max_participants)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                activity["name"],
+                activity["description"],
+                activity["schedule_text"],
+                activity["location"],
+                activity["category"],
+                activity["max_participants"],
+            ),
+        )
+        activity_id = cursor.lastrowid
+
+        for email in activity["participants"]:
+            student_id = _ensure_student(connection, email)
+            connection.execute(
+                """
+                INSERT INTO registrations (activity_id, student_id, status)
+                VALUES (?, ?, ?)
+                """,
+                (activity_id, student_id, REGISTRATION_STATUS_REGISTERED),
+            )
+
+
+def _ensure_student(connection: sqlite3.Connection, email: str, full_name: str | None = None) -> int:
+    normalized_email = email.strip().lower()
+    row = connection.execute(
+        "SELECT id, full_name FROM students WHERE email = ?",
+        (normalized_email,),
+    ).fetchone()
+    if row:
+        if full_name and not row["full_name"]:
+            connection.execute(
+                "UPDATE students SET full_name = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?",
+                (full_name, row["id"]),
+            )
+        return row["id"]
+
+    cursor = connection.execute(
+        """
+        INSERT INTO students (email, full_name)
+        VALUES (?, ?)
+        """,
+        (normalized_email, full_name or _full_name_from_email(normalized_email)),
+    )
+    return cursor.lastrowid
+
+
+def _full_name_from_email(email: str) -> str:
+    local_part = email.split("@", 1)[0]
+    return " ".join(part.capitalize() for part in local_part.replace(".", " ").replace("_", " ").split())
+
+
+def list_activities_legacy() -> dict[str, dict]:
+    with get_connection() as connection:
+        rows = connection.execute(
+            """
+            SELECT
+                a.id,
+                a.name,
+                a.description,
+                a.schedule_text,
+                a.max_participants,
+                s.email
+            FROM activities a
+            LEFT JOIN registrations r
+                ON r.activity_id = a.id AND r.status = ?
+            LEFT JOIN students s
+                ON s.id = r.student_id
+            WHERE a.is_active = 1
+            ORDER BY a.name, s.email
+            """,
+            (REGISTRATION_STATUS_REGISTERED,),
+        ).fetchall()
+
+    activities: dict[str, dict] = {}
+    for row in rows:
+        name = row["name"]
+        if name not in activities:
+            activities[name] = {
+                "description": row["description"],
+                "schedule": row["schedule_text"],
+                "max_participants": row["max_participants"],
+                "participants": [],
+            }
+        if row["email"]:
+            activities[name]["participants"].append(row["email"])
+
+    return activities
+
+
+def signup_student(activity_name: str, email: str) -> None:
+    normalized_email = email.strip().lower()
+    with get_connection() as connection:
+        activity = connection.execute(
+            "SELECT id, max_participants FROM activities WHERE name = ? AND is_active = 1",
+            (activity_name,),
+        ).fetchone()
+        if not activity:
+            raise KeyError("Activity not found")
+
+        student_id = _ensure_student(connection, normalized_email)
+        existing_registration = connection.execute(
+            "SELECT id, status FROM registrations WHERE activity_id = ? AND student_id = ?",
+            (activity["id"], student_id),
+        ).fetchone()
+        if existing_registration and existing_registration["status"] != REGISTRATION_STATUS_CANCELLED:
+            raise ValueError("Student is already signed up")
+
+        registered_count = connection.execute(
+            "SELECT COUNT(*) AS count FROM registrations WHERE activity_id = ? AND status = ?",
+            (activity["id"], REGISTRATION_STATUS_REGISTERED),
+        ).fetchone()["count"]
+        if registered_count >= activity["max_participants"]:
+            raise OverflowError("Activity is full")
+
+        if existing_registration:
+            connection.execute(
+                """
+                UPDATE registrations
+                SET status = ?, updated_at = CURRENT_TIMESTAMP, registered_at = CURRENT_TIMESTAMP
+                WHERE id = ?
+                """,
+                (REGISTRATION_STATUS_REGISTERED, existing_registration["id"]),
+            )
+            return
+
+        connection.execute(
+            """
+            INSERT INTO registrations (activity_id, student_id, status)
+            VALUES (?, ?, ?)
+            """,
+            (activity["id"], student_id, REGISTRATION_STATUS_REGISTERED),
+        )
+
+
+def unregister_student(activity_name: str, email: str) -> None:
+    normalized_email = email.strip().lower()
+    with get_connection() as connection:
+        registration = connection.execute(
+            """
+            SELECT r.id
+            FROM registrations r
+            JOIN activities a ON a.id = r.activity_id
+            JOIN students s ON s.id = r.student_id
+            WHERE a.name = ?
+              AND s.email = ?
+              AND r.status = ?
+            """,
+            (activity_name, normalized_email, REGISTRATION_STATUS_REGISTERED),
+        ).fetchone()
+        if not registration:
+            raise ValueError("Student is not signed up for this activity")
+
+        connection.execute(
+            "UPDATE registrations SET status = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?",
+            (REGISTRATION_STATUS_CANCELLED, registration["id"]),
+        )


### PR DESCRIPTION
## Summary
- add normalized registration endpoints under /api for activities and students
- keep the legacy activity routes in place for the current frontend while reusing the new storage layer
- document the normalized API and ignore generated SQLite database files

Closes #9