### PR TITLE
Add organizer activity management

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -9,6 +9,7 @@ The app persists its core data in a local SQLite database with explicit models f
 - View all available extracurricular activities
 - Sign up for activities
 - Unregister students using stable registration records in the normalized API
+- Create, update, and archive activities through the organizer workflow
 
 ## Getting Started
 
@@ -53,12 +54,36 @@ The app currently exposes both a legacy compatibility API and a normalized API.
 | DELETE | `/api/activities/{activity_id}/registrations/{registration_id}` | Cancel a registration by ID |
 | GET | `/api/students/{student_id}/registrations` | List registrations for one student |
 
+### Organizer management endpoints
+
+| Method | Endpoint | Description |
+| ------ | -------- | ----------- |
+| GET | `/api/management/activities` | List all activities, including archived ones, for organizer workflows |
+| POST | `/api/management/activities` | Create a new activity |
+| PUT | `/api/management/activities/{activity_id}` | Update an existing activity |
+| POST | `/api/management/activities/{activity_id}/archive` | Archive or deactivate an activity |
+| POST | `/api/management/activities/{activity_id}/restore` | Restore an archived activity |
+
 Example registration request body:
 
 ```json
 {
    "email": "student@mergington.edu",
    "full_name": "Student Name"
+}
+```
+
+Example organizer activity request body:
+
+```json
+{
+   "name": "Robotics Club",
+   "description": "Design, build, and program competitive robots.",
+   "schedule_text": "Mondays, 4:00 PM - 5:30 PM",
+   "location": "Lab 204",
+   "category": "club",
+   "max_participants": 16,
+   "is_active": true
 }
 ```
 
@@ -88,3 +113,5 @@ The application now uses persistent core domain models:
 ## Persistence Notes
 
 Default activities are seeded into the database only on first startup. The legacy endpoints remain available for backward compatibility, while the static frontend now uses the normalized API endpoints for listing activities, creating registrations, and cancelling registrations.
+
+The organizer section on the same page uses the management API to create, edit, archive, and restore activities without changing Python source code.

--- a/src/app.py
+++ b/src/app.py
@@ -7,18 +7,22 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
 import os
 from pathlib import Path
-from pydantic import BaseModel
+from pydantic import BaseModel, Field, field_validator
 
 from storage import (
     cancel_registration,
+    create_activity,
     get_activity,
     initialize_database,
     list_activities,
+    list_activities_for_management,
     list_activities_legacy,
     list_activity_registrations,
     list_student_registrations,
     register_student_for_activity,
+    set_activity_active,
     signup_student,
+    update_activity,
     unregister_student,
 )
 
@@ -36,6 +40,42 @@ initialize_database()
 class RegistrationCreateRequest(BaseModel):
     email: str
     full_name: Optional[str] = None
+
+    @field_validator("email")
+    @classmethod
+    def normalize_email(cls, value: str) -> str:
+        return value.strip().lower()
+
+    @field_validator("full_name")
+    @classmethod
+    def normalize_full_name(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+        normalized_value = value.strip()
+        return normalized_value or None
+
+
+class ActivityUpsertRequest(BaseModel):
+    name: str = Field(min_length=3, max_length=100)
+    description: str = Field(min_length=5, max_length=500)
+    schedule_text: str = Field(min_length=3, max_length=120)
+    location: Optional[str] = Field(default=None, max_length=120)
+    category: str = Field(min_length=3, max_length=40)
+    max_participants: int = Field(ge=1, le=500)
+    is_active: bool = True
+
+    @field_validator("name", "description", "schedule_text", "category")
+    @classmethod
+    def strip_required_text(cls, value: str) -> str:
+        return value.strip()
+
+    @field_validator("location")
+    @classmethod
+    def normalize_location(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+        normalized_value = value.strip()
+        return normalized_value or None
 
 
 def _detail_from_exception(error: Exception) -> str:
@@ -57,6 +97,78 @@ def get_activities():
 @app.get("/api/activities")
 def get_normalized_activities():
     return {"activities": list_activities()}
+
+
+@app.get("/api/management/activities")
+def get_management_activities():
+    return {"activities": list_activities_for_management()}
+
+
+@app.post(
+    "/api/management/activities",
+    status_code=201,
+    responses={400: {"description": "Invalid activity request"}},
+)
+def create_managed_activity(payload: ActivityUpsertRequest):
+    try:
+        activity = create_activity(**payload.model_dump())
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=_detail_from_exception(exc)) from exc
+
+    return {
+        "message": f"Created activity {activity['name']}",
+        "activity": activity,
+    }
+
+
+@app.put(
+    "/api/management/activities/{activity_id}",
+    responses={400: {"description": "Invalid activity request"}, 404: {"description": "Activity not found"}},
+)
+def update_managed_activity(activity_id: int, payload: ActivityUpsertRequest):
+    try:
+        activity = update_activity(activity_id, **payload.model_dump())
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=_detail_from_exception(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=_detail_from_exception(exc)) from exc
+
+    return {
+        "message": f"Updated activity {activity['name']}",
+        "activity": activity,
+    }
+
+
+@app.post(
+    "/api/management/activities/{activity_id}/archive",
+    responses={404: {"description": "Activity not found"}},
+)
+def archive_managed_activity(activity_id: int):
+    try:
+        activity = set_activity_active(activity_id, False)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=_detail_from_exception(exc)) from exc
+
+    return {
+        "message": f"Archived activity {activity['name']}",
+        "activity": activity,
+    }
+
+
+@app.post(
+    "/api/management/activities/{activity_id}/restore",
+    responses={404: {"description": "Activity not found"}},
+)
+def restore_managed_activity(activity_id: int):
+    try:
+        activity = set_activity_active(activity_id, True)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=_detail_from_exception(exc)) from exc
+
+    return {
+        "message": f"Restored activity {activity['name']}",
+        "activity": activity,
+    }
 
 
 @app.get(

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -15,19 +15,62 @@ document.addEventListener("DOMContentLoaded", () => {
   const signupForm = document.getElementById("signup-form");
   const fullNameInput = document.getElementById("full-name");
   const messageDiv = document.getElementById("message");
+  const organizerForm = document.getElementById("organizer-form");
+  const organizerList = document.getElementById("organizer-activities-list");
+  const organizerMessageDiv = document.getElementById("organizer-message");
+  const managedActivityIdInput = document.getElementById("managed-activity-id");
+  const managedNameInput = document.getElementById("managed-name");
+  const managedDescriptionInput = document.getElementById("managed-description");
+  const managedScheduleInput = document.getElementById("managed-schedule");
+  const managedLocationInput = document.getElementById("managed-location");
+  const managedCategoryInput = document.getElementById("managed-category");
+  const managedCapacityInput = document.getElementById("managed-capacity");
+  const managedActiveInput = document.getElementById("managed-active");
+  const organizerSubmitButton = document.getElementById("organizer-submit");
+  const organizerResetButton = document.getElementById("organizer-reset");
   const defaultSelectMarkup =
     '<option value="">-- Select an activity --</option>';
-  let messageTimeoutId;
+  const messageTimeouts = new Map();
+  let organizerActivities = [];
 
-  function showMessage(text, type) {
-    messageDiv.textContent = text;
-    messageDiv.className = type;
-    messageDiv.classList.remove("hidden");
+  function showMessage(target, text, type) {
+    target.textContent = text;
+    target.className = type;
+    target.classList.remove("hidden");
 
-    globalThis.clearTimeout(messageTimeoutId);
-    messageTimeoutId = globalThis.setTimeout(() => {
-      messageDiv.classList.add("hidden");
+    globalThis.clearTimeout(messageTimeouts.get(target));
+    const timeoutId = globalThis.setTimeout(() => {
+      target.classList.add("hidden");
     }, 5000);
+    messageTimeouts.set(target, timeoutId);
+  }
+
+  function resetOrganizerForm() {
+    organizerForm.reset();
+    managedActivityIdInput.value = "";
+    managedActiveInput.checked = true;
+    organizerSubmitButton.textContent = "Create Activity";
+    organizerResetButton.classList.add("hidden");
+  }
+
+  function fillOrganizerForm(activity) {
+    managedActivityIdInput.value = String(activity.id);
+    managedNameInput.value = activity.name;
+    managedDescriptionInput.value = activity.description;
+    managedScheduleInput.value = activity.schedule_text;
+    managedLocationInput.value = activity.location || "";
+    managedCategoryInput.value = activity.category;
+    managedCapacityInput.value = String(activity.max_participants);
+    managedActiveInput.checked = activity.is_active;
+    organizerSubmitButton.textContent = "Save Changes";
+    organizerResetButton.classList.remove("hidden");
+    organizerForm.scrollIntoView({ behavior: "smooth", block: "start" });
+  }
+
+  function findOrganizerActivity(activityId) {
+    return organizerActivities.find(
+      (activity) => String(activity.id) === String(activityId)
+    );
   }
 
   async function fetchActivities() {
@@ -117,8 +160,80 @@ document.addEventListener("DOMContentLoaded", () => {
     }
   }
 
+  async function fetchOrganizerActivities() {
+    try {
+      const activitiesResponse = await fetchJson("/api/management/activities");
+      const activities = activitiesResponse.activities;
+      organizerActivities = activities;
+
+      if (!activities.length) {
+        organizerList.innerHTML = "<p>No activities have been created yet.</p>";
+        return;
+      }
+
+      organizerList.innerHTML = '<div class="management-card-grid"></div>';
+      const cardGrid = organizerList.firstElementChild;
+
+      activities.forEach((activity) => {
+        const card = document.createElement("article");
+        card.className = activity.is_active
+          ? "management-card"
+          : "management-card inactive";
+        const visibilityLabel = activity.is_active ? "Active" : "Archived";
+        const toggleLabel = activity.is_active ? "Archive" : "Restore";
+        card.innerHTML = `
+          <span class="management-status ${activity.is_active ? "active" : "inactive"}">${visibilityLabel}</span>
+          <div class="activity-heading">
+            <h4>${activity.name}</h4>
+            <span class="activity-category">${activity.category}</span>
+          </div>
+          <p>${activity.description}</p>
+          <div class="management-meta">
+            <p><strong>Schedule:</strong> ${activity.schedule_text}</p>
+            <p><strong>Location:</strong> ${activity.location || "TBD"}</p>
+            <p><strong>Capacity:</strong> ${activity.registered_count} / ${activity.max_participants}</p>
+          </div>
+          <div class="management-buttons">
+            <button type="button" class="secondary-btn edit-activity-btn" data-activity-id="${activity.id}">Edit</button>
+            <button type="button" class="secondary-btn toggle-activity-btn" data-activity-id="${activity.id}" data-next-state="${activity.is_active ? "archive" : "restore"}">${toggleLabel}</button>
+          </div>
+        `;
+        cardGrid.appendChild(card);
+      });
+    } catch (error) {
+      organizerList.innerHTML =
+        "<p>Failed to load organizer activity management. Please try again later.</p>";
+      console.error("Error fetching organizer activities:", error);
+    }
+  }
+
+  async function refreshAllViews() {
+    await Promise.all([fetchActivities(), fetchOrganizerActivities()]);
+  }
+
+  async function handleActivityVisibilityToggle(event) {
+    const { activityId, nextState } = event.currentTarget.dataset;
+    const endpoint = nextState === "archive" ? "archive" : "restore";
+
+    try {
+      const result = await fetchJson(
+        `/api/management/activities/${encodeURIComponent(activityId)}/${endpoint}`,
+        { method: "POST" }
+      );
+      showMessage(organizerMessageDiv, result.message, "success");
+      await refreshAllViews();
+    } catch (error) {
+      showMessage(
+        organizerMessageDiv,
+        error.message || "Failed to update activity visibility.",
+        "error"
+      );
+      console.error("Error updating activity visibility:", error);
+    }
+  }
+
   async function handleUnregister(event) {
-    const button = event.target;
+    const button = event.currentTarget;
     const { activityId, registrationId } = button.dataset;
 
     try {
@@ -128,10 +243,14 @@ document.addEventListener("DOMContentLoaded", () => {
         )}/registrations/${encodeURIComponent(registrationId)}`,
         { method: "DELETE" }
       );
-      showMessage(result.message, "success");
+      showMessage(messageDiv, result.message, "success");
       fetchActivities();
     } catch (error) {
-      showMessage(error.message || "Failed to unregister. Please try again.", "error");
+      showMessage(
+        messageDiv,
+        error.message || "Failed to unregister. Please try again.",
+        "error"
+      );
       console.error("Error unregistering:", error);
     }
   }
@@ -157,14 +276,84 @@ document.addEventListener("DOMContentLoaded", () => {
           }),
         }
       );
-      showMessage(result.message, "success");
+      showMessage(messageDiv, result.message, "success");
       signupForm.reset();
       fetchActivities();
     } catch (error) {
-      showMessage(error.message || "Failed to sign up. Please try again.", "error");
+      showMessage(
+        messageDiv,
+        error.message || "Failed to sign up. Please try again.",
+        "error"
+      );
       console.error("Error signing up:", error);
     }
   });
 
-  fetchActivities();
+  organizerForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+
+    const activityId = managedActivityIdInput.value;
+    const payload = {
+      name: managedNameInput.value,
+      description: managedDescriptionInput.value,
+      schedule_text: managedScheduleInput.value,
+      location: managedLocationInput.value,
+      category: managedCategoryInput.value,
+      max_participants: Number(managedCapacityInput.value),
+      is_active: managedActiveInput.checked,
+    };
+    const isEditing = Boolean(activityId);
+    const endpoint = isEditing
+      ? `/api/management/activities/${encodeURIComponent(activityId)}`
+      : "/api/management/activities";
+    const method = isEditing ? "PUT" : "POST";
+
+    try {
+      const result = await fetchJson(endpoint, {
+        method,
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(payload),
+      });
+      showMessage(organizerMessageDiv, result.message, "success");
+      resetOrganizerForm();
+      await refreshAllViews();
+    } catch (error) {
+      showMessage(
+        organizerMessageDiv,
+        error.message || "Failed to save activity changes.",
+        "error"
+      );
+      console.error("Error saving activity:", error);
+    }
+  });
+
+  organizerResetButton.addEventListener("click", () => {
+    resetOrganizerForm();
+  });
+
+  organizerList.addEventListener("click", (event) => {
+    const clickedElement = event.target;
+    if (!(clickedElement instanceof HTMLElement)) {
+      return;
+    }
+
+    const editButton = clickedElement.closest(".edit-activity-btn");
+    if (editButton instanceof HTMLElement) {
+      const activity = findOrganizerActivity(editButton.dataset.activityId);
+      if (activity) {
+        fillOrganizerForm(activity);
+      }
+      return;
+    }
+
+    const toggleButton = clickedElement.closest(".toggle-activity-btn");
+    if (toggleButton instanceof HTMLElement) {
+      handleActivityVisibilityToggle({ currentTarget: toggleButton });
+    }
+  });
+
+  resetOrganizerForm();
+  refreshAllViews();
 });

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -43,6 +43,58 @@
         </form>
         <div id="message" class="hidden"></div>
       </section>
+
+      <section id="organizer-container">
+        <h3>Organizer Activity Management</h3>
+        <form id="organizer-form">
+          <input type="hidden" id="managed-activity-id" />
+          <div class="form-group">
+            <label for="managed-name">Activity Name:</label>
+            <input type="text" id="managed-name" required placeholder="Robotics Club" />
+          </div>
+          <div class="form-group">
+            <label for="managed-description">Description:</label>
+            <textarea id="managed-description" required rows="3" placeholder="Build and program robots for competitions"></textarea>
+          </div>
+          <div class="form-group">
+            <label for="managed-schedule">Schedule:</label>
+            <input type="text" id="managed-schedule" required placeholder="Mondays, 4:00 PM - 5:30 PM" />
+          </div>
+          <div class="form-group two-column-fields">
+            <div>
+              <label for="managed-location">Location:</label>
+              <input type="text" id="managed-location" placeholder="Lab 204" />
+            </div>
+            <div>
+              <label for="managed-category">Category:</label>
+              <select id="managed-category" required>
+                <option value="club">Club</option>
+                <option value="class">Class</option>
+                <option value="team">Team</option>
+                <option value="program">Program</option>
+              </select>
+            </div>
+          </div>
+          <div class="form-group two-column-fields">
+            <div>
+              <label for="managed-capacity">Capacity:</label>
+              <input type="number" id="managed-capacity" min="1" max="500" required value="12" />
+            </div>
+            <div class="checkbox-group">
+              <label for="managed-active">Visible to students</label>
+              <input type="checkbox" id="managed-active" checked />
+            </div>
+          </div>
+          <div class="organizer-actions">
+            <button type="submit" id="organizer-submit">Create Activity</button>
+            <button type="button" id="organizer-reset" class="secondary-btn hidden">Cancel Edit</button>
+          </div>
+        </form>
+        <div id="organizer-message" class="hidden"></div>
+        <div id="organizer-activities-list">
+          <p>Loading organizer activity management...</p>
+        </div>
+      </section>
     </main>
 
     <footer>

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -50,6 +50,10 @@ section {
   max-width: 500px;
 }
 
+#organizer-container {
+  max-width: 1030px;
+}
+
 section h3 {
   margin-bottom: 20px;
   padding-bottom: 10px;
@@ -174,12 +178,108 @@ section h3 {
 }
 
 .form-group input,
-.form-group select {
+.form-group select,
+.form-group textarea {
   width: 100%;
   padding: 10px;
   border: 1px solid #ddd;
   border-radius: 4px;
   font-size: 16px;
+}
+
+.form-group textarea {
+  resize: vertical;
+}
+
+.two-column-fields {
+  display: grid;
+  gap: 15px;
+}
+
+@media (min-width: 768px) {
+  .two-column-fields {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+.checkbox-group {
+  align-items: center;
+  display: flex;
+  gap: 10px;
+  padding-top: 28px;
+}
+
+.checkbox-group input {
+  width: auto;
+}
+
+.organizer-actions {
+  display: flex;
+  gap: 12px;
+}
+
+.secondary-btn {
+  background-color: #eceff1;
+  color: #37474f;
+}
+
+.secondary-btn:hover {
+  background-color: #cfd8dc;
+}
+
+.management-card-grid {
+  display: grid;
+  gap: 16px;
+  margin-top: 20px;
+}
+
+@media (min-width: 768px) {
+  .management-card-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.management-card {
+  background-color: #f7f9fc;
+  border: 1px solid #dbe4f0;
+  border-radius: 10px;
+  padding: 16px;
+}
+
+.management-card.inactive {
+  background-color: #f3f4f6;
+  border-color: #d1d5db;
+}
+
+.management-status {
+  border-radius: 999px;
+  display: inline-block;
+  font-size: 12px;
+  font-weight: bold;
+  margin-bottom: 12px;
+  padding: 4px 10px;
+  text-transform: uppercase;
+}
+
+.management-status.active {
+  background-color: #e8f5e9;
+  color: #2e7d32;
+}
+
+.management-status.inactive {
+  background-color: #eceff1;
+  color: #455a64;
+}
+
+.management-meta {
+  color: #4b5563;
+  margin: 10px 0;
+}
+
+.management-buttons {
+  display: flex;
+  gap: 10px;
+  margin-top: 16px;
 }
 
 button {

--- a/src/storage.py
+++ b/src/storage.py
@@ -263,6 +263,29 @@ def _serialize_registration(row: sqlite3.Row) -> dict:
     }
 
 
+def _activity_query(include_inactive: bool = False) -> str:
+    active_filter = "" if include_inactive else "WHERE a.is_active = 1"
+    return f"""
+        SELECT
+            a.id,
+            a.name,
+            a.description,
+            a.schedule_text,
+            a.location,
+            a.category,
+            a.max_participants,
+            a.is_active,
+            a.created_at,
+            a.updated_at,
+            COALESCE(SUM(CASE WHEN r.status = ? THEN 1 ELSE 0 END), 0) AS registered_count,
+            COALESCE(SUM(CASE WHEN r.status = ? THEN 1 ELSE 0 END), 0) AS waitlisted_count
+        FROM activities a
+        LEFT JOIN registrations r ON r.activity_id = a.id
+        {active_filter}
+        GROUP BY a.id
+    """
+
+
 def _get_activity_by_id_row(connection: sqlite3.Connection, activity_id: int) -> sqlite3.Row | None:
     return connection.execute(
         """
@@ -323,26 +346,17 @@ def _get_registration_row(connection: sqlite3.Connection, registration_id: int) 
 def list_activities() -> list[dict]:
     with get_connection() as connection:
         rows = connection.execute(
-            """
-            SELECT
-                a.id,
-                a.name,
-                a.description,
-                a.schedule_text,
-                a.location,
-                a.category,
-                a.max_participants,
-                a.is_active,
-                a.created_at,
-                a.updated_at,
-                COALESCE(SUM(CASE WHEN r.status = ? THEN 1 ELSE 0 END), 0) AS registered_count,
-                COALESCE(SUM(CASE WHEN r.status = ? THEN 1 ELSE 0 END), 0) AS waitlisted_count
-            FROM activities a
-            LEFT JOIN registrations r ON r.activity_id = a.id
-            WHERE a.is_active = 1
-            GROUP BY a.id
-            ORDER BY a.name
-            """,
+            _activity_query() + " ORDER BY a.name",
+            (REGISTRATION_STATUS_REGISTERED, REGISTRATION_STATUS_WAITLISTED),
+        ).fetchall()
+
+    return [_serialize_activity(row) for row in rows]
+
+
+def list_activities_for_management() -> list[dict]:
+    with get_connection() as connection:
+        rows = connection.execute(
+            _activity_query(include_inactive=True) + " ORDER BY a.is_active DESC, a.name",
             (REGISTRATION_STATUS_REGISTERED, REGISTRATION_STATUS_WAITLISTED),
         ).fetchall()
 
@@ -356,6 +370,117 @@ def get_activity(activity_id: int) -> dict:
             raise KeyError(ACTIVITY_NOT_FOUND)
 
     return _serialize_activity(row)
+
+
+def create_activity(
+    name: str,
+    description: str,
+    schedule_text: str,
+    category: str,
+    max_participants: int,
+    location: str | None = None,
+    is_active: bool = True,
+) -> dict:
+    with get_connection() as connection:
+        try:
+            cursor = connection.execute(
+                """
+                INSERT INTO activities (
+                    name,
+                    description,
+                    schedule_text,
+                    location,
+                    category,
+                    max_participants,
+                    is_active
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    name,
+                    description,
+                    schedule_text,
+                    location,
+                    category,
+                    max_participants,
+                    1 if is_active else 0,
+                ),
+            )
+        except sqlite3.IntegrityError as error:
+            raise ValueError("Activity name already exists") from error
+
+        activity_row = _get_activity_by_id_row(connection, cursor.lastrowid)
+
+    return _serialize_activity(activity_row)
+
+
+def update_activity(
+    activity_id: int,
+    name: str,
+    description: str,
+    schedule_text: str,
+    category: str,
+    max_participants: int,
+    location: str | None = None,
+    is_active: bool = True,
+) -> dict:
+    with get_connection() as connection:
+        existing_activity = _get_activity_by_id_row(connection, activity_id)
+        if not existing_activity:
+            raise KeyError(ACTIVITY_NOT_FOUND)
+        if existing_activity["registered_count"] > max_participants:
+            raise ValueError("Capacity cannot be lower than current registered count")
+
+        try:
+            connection.execute(
+                """
+                UPDATE activities
+                SET name = ?,
+                    description = ?,
+                    schedule_text = ?,
+                    location = ?,
+                    category = ?,
+                    max_participants = ?,
+                    is_active = ?,
+                    updated_at = CURRENT_TIMESTAMP
+                WHERE id = ?
+                """,
+                (
+                    name,
+                    description,
+                    schedule_text,
+                    location,
+                    category,
+                    max_participants,
+                    1 if is_active else 0,
+                    activity_id,
+                ),
+            )
+        except sqlite3.IntegrityError as error:
+            raise ValueError("Activity name already exists") from error
+
+        activity_row = _get_activity_by_id_row(connection, activity_id)
+
+    return _serialize_activity(activity_row)
+
+
+def set_activity_active(activity_id: int, is_active: bool) -> dict:
+    with get_connection() as connection:
+        existing_activity = _get_activity_by_id_row(connection, activity_id)
+        if not existing_activity:
+            raise KeyError(ACTIVITY_NOT_FOUND)
+
+        connection.execute(
+            """
+            UPDATE activities
+            SET is_active = ?, updated_at = CURRENT_TIMESTAMP
+            WHERE id = ?
+            """,
+            (1 if is_active else 0, activity_id),
+        )
+        activity_row = _get_activity_by_id_row(connection, activity_id)
+
+    return _serialize_activity(activity_row)
 
 
 def list_activity_registrations(activity_id: int) -> list[dict]:


### PR DESCRIPTION
## Summary
- add organizer management endpoints for creating, updating, archiving, and restoring activities
- extend the static page with an organizer workflow for maintaining activities without editing Python source
- document the management API and enforce validation for required fields and capacity changes

Closes #11